### PR TITLE
refactored enums inside plan_helper

### DIFF
--- a/lbplanner/services/plan/accept_invite.php
+++ b/lbplanner/services/plan/accept_invite.php
@@ -23,6 +23,8 @@ use external_value;
 use local_lbplanner\helpers\user_helper;
 use local_lbplanner\helpers\plan_helper;
 use local_lbplanner\helpers\notifications_helper;
+use local_lbplanner\helpers\PLAN_ACCESS_TYPE;
+use local_lbplanner\helpers\PLAN_INVITE_STATE;
 
 /**
  * Update a invite from the plan.
@@ -49,7 +51,7 @@ class plan_accept_invite extends external_api {
             throw new \moodle_exception('Invite not found');
         }
         if (!$DB->record_exists(plan_helper::INVITES_TABLE,
-        array( 'id' => $inviteid, 'inviteeid' => $userid, 'status' => plan_helper::INVITE_PENDING))) {
+        array( 'id' => $inviteid, 'inviteeid' => $userid, 'status' => PLAN_INVITE_STATE::PENDING->value))) {
             throw new \moodle_exception('Invite already accepted or declined');
         }
 
@@ -57,7 +59,7 @@ class plan_accept_invite extends external_api {
         array(
             'id' => $inviteid,
             'inviteeid' => $userid,
-            'status' => plan_helper::INVITE_PENDING,
+            'status' => PLAN_INVITE_STATE::PENDING->value,
         ),
         '*',
         MUST_EXIST
@@ -99,18 +101,18 @@ class plan_accept_invite extends external_api {
             MUST_EXIST
         );
 
-        $invite->status = plan_helper::INVITE_ACCEPTED;
+        $invite->status = PLAN_INVITE_STATE::ACCEPTED->value;
 
         $DB->update_record(plan_helper::INVITES_TABLE, $invite);
 
-        $planaccess->accesstype = plan_helper::ACCESS_TYPE_READ;
+        $planaccess->accesstype = PLAN_ACCESS_TYPE::READ->value;
         $planaccess->planid = $invite->planid;
 
         $DB->update_record(plan_helper::ACCESS_TABLE, $planaccess);
         $invites = plan_helper::get_invites_send($userid);
         foreach ($invites as $invite) {
-            if ($invite->status == plan_helper::INVITE_PENDING) {
-                $invite->status = plan_helper::INVITE_EXPIRED;
+            if ($invite->status == PLAN_INVITE_STATE::PENDING->value) {
+                $invite->status = PLAN_INVITE_STATE::EXPIRED->value;
                 $DB->update_record(plan_helper::INVITES_TABLE, $invite);
             }
         }

--- a/lbplanner/services/plan/decline_invite.php
+++ b/lbplanner/services/plan/decline_invite.php
@@ -23,6 +23,7 @@ use external_value;
 use local_lbplanner\helpers\user_helper;
 use local_lbplanner\helpers\plan_helper;
 use local_lbplanner\helpers\notifications_helper;
+use local_lbplanner\helpers\PLAN_INVITE_STATE;
 
 /**
  * Update a invite from the plan.
@@ -49,7 +50,7 @@ class plan_decline_invite extends external_api {
             throw new \moodle_exception('Invite not found');
         }
         if (!$DB->record_exists(plan_helper::INVITES_TABLE,
-        array('id' => $inviteid, 'inviteeid' => $userid, 'status' => plan_helper::INVITE_PENDING))) {
+        array('id' => $inviteid, 'inviteeid' => $userid, 'status' => PLAN_INVITE_STATE::PENDING->value))) {
             throw new \moodle_exception('Invite already accepted or declined');
         }
 
@@ -57,7 +58,7 @@ class plan_decline_invite extends external_api {
         array(
             'id' => $inviteid,
             'inviteeid' => $userid,
-            'status' => plan_helper::INVITE_PENDING,
+            'status' => PLAN_INVITE_STATE::PENDING->value,
         ),
         '*',
         MUST_EXIST
@@ -70,7 +71,7 @@ class plan_decline_invite extends external_api {
             notifications_helper::TRIGGER_INVITE_DECLINED
         );
 
-        $invite->status = plan_helper::INVITE_DECLINED;
+        $invite->status = PLAN_INVITE_STATE::DECLINED->value;
 
         $DB->update_record(plan_helper::INVITES_TABLE, $invite);
 

--- a/lbplanner/services/plan/invite_user.php
+++ b/lbplanner/services/plan/invite_user.php
@@ -23,6 +23,7 @@ use external_value;
 use local_lbplanner\helpers\plan_helper;
 use local_lbplanner\helpers\user_helper;
 use local_lbplanner\helpers\notifications_helper;
+use local_lbplanner\helpers\PLAN_INVITE_STATE;
 
 /**
  * Invite a user to the plan.
@@ -77,7 +78,7 @@ class plan_invite_user extends external_api {
 
         if ($DB->record_exists(
                 plan_helper::INVITES_TABLE,
-                array('inviteeid' => $inviteeid, 'planid' => $planid, 'status' => plan_helper::INVITE_PENDING)
+                array('inviteeid' => $inviteeid, 'planid' => $planid, 'status' => PLAN_INVITE_STATE::PENDING->value)
             )) {
             throw new \moodle_exception('User is already invited');
         }
@@ -95,7 +96,7 @@ class plan_invite_user extends external_api {
         $invite->inviterid = $inviterid;
         $invite->inviteeid = $inviteeid;
         $invite->timestamp = time();
-        $invite->status = plan_helper::INVITE_PENDING;
+        $invite->status = PLAN_INVITE_STATE::PENDING->value;
 
         $invite->id = $DB->insert_record(plan_helper::INVITES_TABLE, $invite);
 

--- a/lbplanner/services/plan/update_access.php
+++ b/lbplanner/services/plan/update_access.php
@@ -19,6 +19,7 @@ namespace local_lbplanner_services;
 use external_api;
 use external_function_parameters;
 use external_value;
+use local_lbplanner\helpers\PLAN_ACCESS_TYPE;
 use local_lbplanner\helpers\plan_helper;
 use local_lbplanner\helpers\user_helper;
 
@@ -73,7 +74,9 @@ class plan_update_access extends external_api {
             throw new \moodle_exception('Access denied');
         }
 
-        if ($accesstype < 0 || $accesstype > 2) {
+        $accesstype_obj = PLAN_ACCESS_TYPE::tryFrom($accesstype);
+
+        if ($accesstype_obj === null) {
             throw new \moodle_exception('Access type not valid');
         }
 
@@ -85,8 +88,8 @@ class plan_update_access extends external_api {
             throw new \moodle_exception('Cannot change permissions for the plan owner');
         }
 
-        if ($accesstype == plan_helper::ACCESS_TYPE_OWNER) {
-            throw new \moodle_exception('Cannot change permissions to owner');
+        if ($accesstype_obj === PLAN_ACCESS_TYPE::OWNER) {
+            throw new \moodle_exception('Cannot change permission to owner');
         }
 
         $access = $DB->get_record(plan_helper::ACCESS_TABLE, array('planid' => $planid, 'userid' => $memberid), '*', MUST_EXIST);

--- a/lbplanner/services/user/delete_user.php
+++ b/lbplanner/services/user/delete_user.php
@@ -25,6 +25,8 @@ use local_lbplanner\helpers\user_helper;
 use local_lbplanner\helpers\plan_helper;
 use local_lbplanner\helpers\course_helper;
 use local_lbplanner\helpers\notifications_helper;
+use local_lbplanner\helpers\PLAN_ACCESS_TYPE;
+use local_lbplanner\helpers\PLAN_INVITE_STATE;
 
 /**
  * Removes all user data stored by the lbplanner app
@@ -55,7 +57,7 @@ class user_delete_user extends external_api {
 
         $planid = plan_helper::get_plan_id($userid);
 
-        if (plan_helper::get_access_type($planid, $userid) == plan_helper::ACCESS_TYPE_OWNER) {
+        if (plan_helper::get_access_type($planid, $userid) === PLAN_ACCESS_TYPE::OWNER) {
             if (plan_helper::get_plan_members($planid) > 1) {
                 self::call_external_function('local_lbplanner_plan_leave_plan', array('userid' => $userid, 'planid' => $planid));
             } else {
@@ -71,8 +73,8 @@ class user_delete_user extends external_api {
 
         $invites = plan_helper::get_invites_send($userid);
         foreach ($invites as $invite) {
-            if ($invite->status == plan_helper::INVITE_PENDING) {
-                $invite->status = plan_helper::INVITE_EXPIRED;
+            if ($invite->status == PLAN_INVITE_STATE::PENDING->value) {
+                $invite->status = PLAN_INVITE_STATE::EXPIRED->value;
                 $DB->update_record(plan_helper::INVITES_TABLE, $invite);
             }
         }

--- a/lbplanner/services/user/register_user.php
+++ b/lbplanner/services/user/register_user.php
@@ -23,6 +23,8 @@ use external_value;
 use local_lbplanner\helpers\user_helper;
 use local_lbplanner\helpers\plan_helper;
 use local_lbplanner\helpers\notifications_helper;
+use local_lbplanner\helpers\PLAN_ACCESS_TYPE;
+use local_lbplanner\helpers\PLAN_EK;
 
 /**
  * Register a new user in the lbplanner app.
@@ -62,13 +64,13 @@ class user_register_user extends external_api {
 
         $plan = new \stdClass();
         $plan->name = 'Plan for ' . $mdluser->firstname;
-        $plan->enableek = plan_helper::EK_DISABLED;
+        $plan->enableek = PLAN_EK::DISABLED->value;
 
         $planid = $DB->insert_record(plan_helper::TABLE, $plan);
 
         $planaccess = new \stdClass();
         $planaccess->userid = $userid;
-        $planaccess->accesstype = plan_helper::ACCESS_TYPE_OWNER;
+        $planaccess->accesstype = PLAN_ACCESS_TYPE::OWNER->value;
         $planaccess->planid = $planid;
 
         $DB->insert_record(plan_helper::ACCESS_TABLE, $planaccess);


### PR DESCRIPTION
refactored constants inside helper class to enums outside it. This is safer and can be used for easy validation too. I hope this doesn't cause too many merge conflicts :/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/necodeIT/lb_planner/50)
<!-- Reviewable:end -->
