### PR TITLE
fixed shortname too long

### DIFF
--- a/lbplanner/services/courses/get_all_courses.php
+++ b/lbplanner/services/courses/get_all_courses.php
@@ -69,6 +69,9 @@ class courses_get_all_courses extends external_api {
             if (strpos($shortname, ' ') !== false) {
                     $shortname = substr($shortname, 0, strpos($shortname, ' '));
             }
+            if (strlen($shortname) >= 5) {
+                    $shortname = substr($shortname, 0, 5);
+            }
             // Check if the course is from the current year.
             if (course_helper::check_current_year($courseid)) {
                     continue;


### PR DESCRIPTION
Courses where able to input a too long shortname. DB doesnt like that

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/necodeIT/lb_planner/67)
<!-- Reviewable:end -->
